### PR TITLE
Add passphrase guard just for search page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # ChatGPTcorpus
+
+This repository contains a small Vue frontend and an ASP.NET backend.
+
+## Securing the Frontend
+
+The search page of the frontend can be protected with a shared passphrase. Copy `frontend/.env.example` to `frontend/.env` and change the value of `VITE_ACCESS_PASSPHRASE` to the passphrase you want to require. When enabled, users must enter the passphrase before the `/search` route is displayed.
+
+See `frontend/README.md` for details on running the frontend.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,3 @@
+# Rename this file to .env and set your desired passphrase
+# Users must enter this passphrase to access the /search page
+VITE_ACCESS_PASSPHRASE=changeme

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,5 +1,11 @@
-# Vue 3 + Vite
+# Frontend
 
-This template should help get you started developing with Vue 3 in Vite. The template uses Vue 3 `<script setup>` SFCs, check out the [script setup docs](https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup) to learn more.
+## Setup
 
-Learn more about IDE Support for Vue in the [Vue Docs Scaling up Guide](https://vuejs.org/guide/scaling-up/tooling.html#ide-support).
+1. Copy `.env.example` to `.env` and change the value of `VITE_ACCESS_PASSPHRASE` to your chosen passphrase. When set, the `/search` page will prompt users for this passphrase before showing results.
+2. Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,11 +1,14 @@
 <script setup>
 import Navbar from './components/Navbar.vue'
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
 </script>
 
 <template>
-  <div class="bg-white flex flex-col">
-    <Navbar />
-    <main class="pt-16 flex-1 flex flex-col">
+  <div class="bg-white flex flex-col min-h-screen">
+    <Navbar v-if="route.name !== 'login'" />
+    <main :class="route.name !== 'login' ? 'pt-16 flex-1 flex flex-col' : 'flex-1 flex flex-col'">
       <router-view />
     </main>
   </div>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -3,10 +3,16 @@ import SearchView from '../views/SearchView.vue'
 import ContributeView from '../views/ContributeView.vue'
 import CorpusInfoView from '../views/CorpusInfoView.vue'
 import ConversationView from '../views/ConversationView.vue'
+import LoginView from '../views/LoginView.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
+    {
+      path: '/login',
+      name: 'login',
+      component: LoginView
+    },
     {
       path: '/',
       redirect: '/search'
@@ -34,4 +40,15 @@ const router = createRouter({
   ]
 })
 
-export default router 
+router.beforeEach((to, from, next) => {
+  const required = import.meta.env.VITE_ACCESS_PASSPHRASE
+  if (required && to.name === 'search') {
+    const authenticated = localStorage.getItem('authenticated') === 'true'
+    if (!authenticated) {
+      return next({ name: 'login' })
+    }
+  }
+  next()
+})
+
+export default router

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-gray-100">
+    <form @submit.prevent="checkPassphrase" class="bg-white p-6 rounded shadow space-y-4 w-80">
+      <h1 class="text-xl font-semibold text-center">Enter Passphrase</h1>
+      <input
+        v-model="input"
+        type="password"
+        placeholder="Passphrase"
+        class="w-full border px-3 py-2 rounded"
+      />
+      <p v-if="error" class="text-red-600 text-sm">{{ error }}</p>
+      <button type="submit" class="w-full btn-primary">Enter</button>
+    </form>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+const input = ref('')
+const error = ref('')
+const router = useRouter()
+
+const checkPassphrase = () => {
+  const required = import.meta.env.VITE_ACCESS_PASSPHRASE
+  if (input.value === required) {
+    localStorage.setItem('authenticated', 'true')
+    router.replace({ name: 'search' })
+  } else {
+    error.value = 'Invalid passphrase'
+  }
+}
+</script>
+
+<style scoped>
+.btn-primary {
+  @apply bg-purple-600 hover:bg-purple-700 text-white font-semibold py-2 px-4 rounded;
+}
+</style>


### PR DESCRIPTION
## Summary
- limit login requirement to the search page only
- document the search page protection in README files
- update example `.env` comments

## Testing
- `dotnet test` *(fails: UploadZip_ExtractsAndImportsCorrectly)*

------
https://chatgpt.com/codex/tasks/task_e_6846a8f8e824832dac7883fc6064df04